### PR TITLE
feat(tui): data-driven character, inventory, quest views with real-time updates

### DIFF
--- a/internal/engine/convert.go
+++ b/internal/engine/convert.go
@@ -9,9 +9,11 @@ func GameStateFromFull(gs *game.GameState) *GameState {
 		return nil
 	}
 	return &GameState{
-		CurrentLocation: gs.CurrentLocation,
-		PlayerCharacter: gs.Player,
-		NPCsPresent:     gs.NearbyNPCs,
-		ActiveQuests:     gs.ActiveQuests,
+		CurrentLocation:       gs.CurrentLocation,
+		PlayerCharacter:       gs.Player,
+		NPCsPresent:           gs.NearbyNPCs,
+		ActiveQuests:          gs.ActiveQuests,
+		ActiveQuestObjectives: gs.ActiveQuestObjectives,
+		PlayerInventory:       gs.PlayerInventory,
 	}
 }

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -124,4 +124,8 @@ type GameState struct {
 	NPCsPresent []domain.NPC
 	// ActiveQuests lists the quests the player is currently pursuing.
 	ActiveQuests []domain.Quest
+	// ActiveQuestObjectives maps quest IDs to their ordered objectives.
+	ActiveQuestObjectives map[uuid.UUID][]domain.QuestObjective
+	// PlayerInventory lists the items the player is carrying.
+	PlayerInventory []domain.Item
 }

--- a/tui/app.go
+++ b/tui/app.go
@@ -54,6 +54,12 @@ type narrativeStreamDoneMsg struct {
 	choices []engine.Choice
 }
 
+// gameStateUpdatedMsg carries refreshed game state to be forwarded to sub-views.
+type gameStateUpdatedMsg struct {
+	state *engine.GameState
+	err   error
+}
+
 // App is the root Bubble Tea model for Game Master. It tracks the active
 // ViewState and delegates Init/Update/View to the appropriate sub-model via
 // the embedded Router. Global key bindings (quit, view-switching) are handled
@@ -124,8 +130,14 @@ func (a App) ActiveViewState() ViewState {
 	return a.viewState
 }
 
-// Init implements tea.Model. No start-up commands are needed.
-func (a App) Init() tea.Cmd { return nil }
+// Init implements tea.Model. When an engine is present, it fetches the
+// initial game state so sub-views are populated on boot.
+func (a App) Init() tea.Cmd {
+	if a.engine != nil {
+		return a.fetchGameState()
+	}
+	return nil
+}
 
 // Update implements tea.Model. It handles global key bindings (quit and view
 // switching) and forwards all other messages to the active sub-model.
@@ -233,6 +245,25 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		a.turnBusy = false
 		if nv := a.narrativeView(); nv != nil {
 			nv.SetChoices(msg.choices)
+		}
+		// After a turn completes, refresh sub-views with latest game state.
+		if a.engine != nil {
+			return a, a.fetchGameState()
+		}
+		return a, nil
+
+	case gameStateUpdatedMsg:
+		if msg.err != nil {
+			if nv := a.narrativeView(); nv != nil {
+				nv.AddEntry(narrative.Entry{
+					Kind: narrative.KindSystem,
+					Text: fmt.Sprintf("State refresh error: %v", msg.err),
+				})
+			}
+			return a, nil
+		}
+		if msg.state != nil {
+			return a, a.distributeState(msg.state)
 		}
 		return a, nil
 
@@ -353,4 +384,57 @@ func nextNarrativeChunk(text string) (chunk, remaining string) {
 		return text, ""
 	}
 	return string(runes[:narrativeChunkSize]), string(runes[narrativeChunkSize:])
+}
+
+
+// fetchGameState returns a tea.Cmd that queries the engine for current state.
+func (a App) fetchGameState() tea.Cmd {
+	ctx := a.ctx
+	eng := a.engine
+	campaignID := dbutil.FromPgtype(a.campaign.ID)
+	return func() tea.Msg {
+		if eng == nil {
+			return gameStateUpdatedMsg{}
+		}
+		state, err := eng.GetGameState(ctx, campaignID)
+		return gameStateUpdatedMsg{state: state, err: err}
+	}
+}
+
+// distributeState forwards the refreshed game state to each sub-view,
+// regardless of which view is currently active.
+func (a *App) distributeState(state *engine.GameState) tea.Cmd {
+	var cmds []tea.Cmd
+
+	// Character view.
+	cmds = append(cmds, a.forwardToView(int(ViewCharacterSheet), character.UpdateMsg{
+		Player: state.PlayerCharacter,
+	}))
+
+	// Inventory view.
+	cmds = append(cmds, a.forwardToView(int(ViewInventory), inventory.UpdateMsg{
+		Items: state.PlayerInventory,
+	}))
+
+	// Quest log view.
+	cmds = append(cmds, a.forwardToView(int(ViewQuestLog), quest.UpdateMsg{
+		Quests:     state.ActiveQuests,
+		Objectives: state.ActiveQuestObjectives,
+	}))
+
+	return tea.Batch(cmds...)
+}
+
+// forwardToView sends a message to a specific view by index and captures any
+// command it returns. This allows updating non-active views without switching tabs.
+func (a *App) forwardToView(idx int, msg tea.Msg) tea.Cmd {
+	if idx < 0 || idx >= len(a.router.tabs) {
+		return nil
+	}
+	view := a.router.tabs[idx].View
+	updated, cmd := view.Update(msg)
+	if v, ok := updated.(View); ok {
+		a.router.tabs[idx].View = v
+	}
+	return cmd
 }

--- a/tui/app_test.go
+++ b/tui/app_test.go
@@ -29,11 +29,13 @@ var testCfg = config.Config{
 var testCampaign = statedb.Campaign{}
 
 type mockGameEngine struct {
-	processTurnFn     func(context.Context, uuid.UUID, string) (*engine.TurnResult, error)
-	loadCampaignFn    func(context.Context, uuid.UUID) error
-	inputs            []string
-	campaignIDs       []uuid.UUID
-	loadedCampaignIDs []uuid.UUID
+	processTurnFn      func(context.Context, uuid.UUID, string) (*engine.TurnResult, error)
+	getGameStateFn     func(context.Context, uuid.UUID) (*engine.GameState, error)
+	loadCampaignFn     func(context.Context, uuid.UUID) error
+	inputs             []string
+	campaignIDs        []uuid.UUID
+	stateCampaignIDs   []uuid.UUID
+	loadedCampaignIDs  []uuid.UUID
 }
 
 func (m *mockGameEngine) ProcessTurn(ctx context.Context, campaignID uuid.UUID, input string) (*engine.TurnResult, error) {
@@ -45,7 +47,11 @@ func (m *mockGameEngine) ProcessTurn(ctx context.Context, campaignID uuid.UUID, 
 	return &engine.TurnResult{}, nil
 }
 
-func (m *mockGameEngine) GetGameState(context.Context, uuid.UUID) (*engine.GameState, error) {
+func (m *mockGameEngine) GetGameState(ctx context.Context, campaignID uuid.UUID) (*engine.GameState, error) {
+	m.stateCampaignIDs = append(m.stateCampaignIDs, campaignID)
+	if m.getGameStateFn != nil {
+		return m.getGameStateFn(ctx, campaignID)
+	}
 	return &engine.GameState{}, nil
 }
 
@@ -59,6 +65,53 @@ func (m *mockGameEngine) LoadCampaign(ctx context.Context, campaignID uuid.UUID)
 		return m.loadCampaignFn(ctx, campaignID)
 	}
 	return nil
+}
+
+func sampleGameState() *engine.GameState {
+	questID := uuid.New()
+	return &engine.GameState{
+		PlayerCharacter: domain.PlayerCharacter{
+			ID:         uuid.New(),
+			CampaignID: uuid.New(),
+			UserID:     uuid.New(),
+			Name:       "Aric the Bold",
+			Level:      5,
+			HP:         18,
+			MaxHP:      25,
+			Experience: 1200,
+			Status:     "healthy",
+		},
+		PlayerInventory: []domain.Item{
+			{
+				ID:          uuid.New(),
+				CampaignID:  uuid.New(),
+				Name:        "Health Potion",
+				ItemType:    domain.ItemTypeConsumable,
+				Quantity:    3,
+				Description: "Restores health.",
+				Rarity:      "common",
+			},
+		},
+		ActiveQuests: []domain.Quest{
+			{
+				ID:        questID,
+				Title:     "The Missing Merchant",
+				QuestType: domain.QuestTypeShortTerm,
+				Status:    domain.QuestStatusActive,
+			},
+		},
+		ActiveQuestObjectives: map[uuid.UUID][]domain.QuestObjective{
+			questID: {
+				{
+					ID:          uuid.New(),
+					QuestID:     questID,
+					Description: "Speak to the innkeeper",
+					Completed:   true,
+					OrderIndex:  0,
+				},
+			},
+		},
+	}
 }
 
 func keyForView(view ViewState) rune {
@@ -399,5 +452,127 @@ func TestNextNarrativeChunkPreservesUTF8Runes(t *testing.T) {
 	}
 	if remaining != "🙂" {
 		t.Fatalf("unexpected remaining chunk: %q", remaining)
+	}
+}
+
+
+
+func TestAppInitWithEngineFetchesInitialStateAndPopulatesViews(t *testing.T) {
+	campaignID := uuid.New()
+	state := sampleGameState()
+	mockEngine := &mockGameEngine{
+		getGameStateFn: func(_ context.Context, gotCampaignID uuid.UUID) (*engine.GameState, error) {
+			if gotCampaignID != campaignID {
+				t.Fatalf("expected campaign id %s, got %s", campaignID, gotCampaignID)
+			}
+			return state, nil
+		},
+	}
+
+	app := NewAppWithEngine(testCfg, statedb.Campaign{ID: dbutil.ToPgtype(campaignID)}, context.Background(), mockEngine)
+	sized, _ := app.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+	app = sized.(App)
+
+	cmd := app.Init()
+	if cmd == nil {
+		t.Fatal("expected Init to return a fetchGameState command when engine is present")
+	}
+
+	model, followup := app.Update(cmd())
+	updated := model.(App)
+	if followup != nil {
+		t.Fatal("expected no follow-up command when distributing initial state")
+	}
+	if len(mockEngine.stateCampaignIDs) != 1 || mockEngine.stateCampaignIDs[0] != campaignID {
+		t.Fatalf("expected one initial state fetch for campaign %s, got %#v", campaignID, mockEngine.stateCampaignIDs)
+	}
+
+	characterView := updated.router.tabs[int(ViewCharacterSheet)].View.View()
+	if !strings.Contains(characterView, "Aric the Bold") {
+		t.Fatalf("expected character view to contain fetched player name, got:\n%s", characterView)
+	}
+	inventoryView := updated.router.tabs[int(ViewInventory)].View.View()
+	if !strings.Contains(inventoryView, "Health Potion") {
+		t.Fatalf("expected inventory view to contain fetched item, got:\n%s", inventoryView)
+	}
+	questView := updated.router.tabs[int(ViewQuestLog)].View.View()
+	if !strings.Contains(questView, "The Missing Merchant") {
+		t.Fatalf("expected quest view to contain fetched quest, got:\n%s", questView)
+	}
+}
+
+func TestAppNarrativeStreamDoneFetchesUpdatedState(t *testing.T) {
+	campaignID := uuid.New()
+	state := sampleGameState()
+	mockEngine := &mockGameEngine{
+		processTurnFn: func(context.Context, uuid.UUID, string) (*engine.TurnResult, error) {
+			return &engine.TurnResult{
+				Narrative: "A hidden passage opens behind the tapestry.",
+			}, nil
+		},
+		getGameStateFn: func(_ context.Context, gotCampaignID uuid.UUID) (*engine.GameState, error) {
+			if gotCampaignID != campaignID {
+				t.Fatalf("expected campaign id %s, got %s", campaignID, gotCampaignID)
+			}
+			return state, nil
+		},
+	}
+
+	app := NewAppWithEngine(testCfg, statedb.Campaign{ID: dbutil.ToPgtype(campaignID)}, context.Background(), mockEngine)
+	sized, _ := app.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+	app = sized.(App)
+
+	model, cmd := app.Update(narrative.SubmitMsg{Input: "inspect the tapestry"})
+	updated := model.(App)
+	if cmd == nil {
+		t.Fatal("expected submit to return a command")
+	}
+
+	model, cmd = updated.Update(updated.processTurn("inspect the tapestry")())
+	updated = model.(App)
+	if cmd == nil {
+		t.Fatal("expected narrative streaming command after processing turn")
+	}
+
+	for updated.turnBusy {
+		msg := cmd()
+		model, cmd = updated.Update(msg)
+		updated = model.(App)
+	}
+
+	if cmd == nil {
+		t.Fatal("expected state refresh command after narrative stream completes")
+	}
+
+	model, _ = updated.Update(cmd())
+	updated = model.(App)
+	if len(mockEngine.stateCampaignIDs) != 1 || mockEngine.stateCampaignIDs[0] != campaignID {
+		t.Fatalf("expected one state refresh fetch for campaign %s, got %#v", campaignID, mockEngine.stateCampaignIDs)
+	}
+
+	characterView := updated.router.tabs[int(ViewCharacterSheet)].View.View()
+	if !strings.Contains(characterView, "Aric the Bold") {
+		t.Fatalf("expected character view to update after turn, got:\n%s", characterView)
+	}
+	inventoryView := updated.router.tabs[int(ViewInventory)].View.View()
+	if !strings.Contains(inventoryView, "Health Potion") {
+		t.Fatalf("expected inventory view to update after turn, got:\n%s", inventoryView)
+	}
+	questView := updated.router.tabs[int(ViewQuestLog)].View.View()
+	if !strings.Contains(questView, "Speak to the innkeeper") {
+		t.Fatalf("expected quest objectives to update after turn, got:\n%s", questView)
+	}
+}
+
+func TestAppStateFetchErrorAddsSystemMessage(t *testing.T) {
+	app := NewAppWithEngine(testCfg, testCampaign, context.Background(), &mockGameEngine{})
+	sized, _ := app.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+	app = sized.(App)
+
+	model, _ := app.Update(gameStateUpdatedMsg{err: errors.New("state db unavailable")})
+	updated := model.(App)
+
+	if !strings.Contains(updated.View(), "State refresh error: state db unavailable") {
+		t.Fatalf("expected state fetch error to be shown in narrative view, got:\n%s", updated.View())
 	}
 }

--- a/tui/character/character.go
+++ b/tui/character/character.go
@@ -1,57 +1,278 @@
 // Package character provides the character sheet view for the TUI.
-// It renders a placeholder character sheet using the shared styles package.
-// Real character data will be populated in the player character management epic.
+// It renders player stats, HP/XP bars, abilities, and status using domain data.
 package character
 
 import (
-	tea "github.com/charmbracelet/bubbletea"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
 
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/PatrickFanella/game-master/internal/domain"
 	"github.com/PatrickFanella/game-master/tui/styles"
+)
+
+const (
+	barWidth       = 20
+	xpPerLevel     = 1000
+	containerHPad  = 4 // border (2) + padding (2)
+	containerVPad  = 2 // header line + spacer
+	filledBlock    = "█"
+	emptyBlock     = "░"
 )
 
 // NavigateBackMsg is emitted when the user presses Escape to return to the
 // narrative view.
 type NavigateBackMsg struct{}
 
+// UpdateMsg delivers fresh player data to the character view.
+type UpdateMsg struct {
+	Player domain.PlayerCharacter
+}
+
 // Model is the Bubble Tea model for the character sheet view.
 type Model struct {
 	width, height int
+	player        domain.PlayerCharacter
+	loaded        bool
+	viewport      viewport.Model
 }
 
 // New returns a freshly initialised character Model.
 func New() Model {
-	return Model{}
+	vp := viewport.New(40, 1)
+	return Model{viewport: vp}
 }
 
 // SetSize updates the viewport dimensions.
 func (m *Model) SetSize(width, height int) {
 	m.width = width
 	m.height = height
+	vpWidth := width - containerHPad
+	vpHeight := height - containerVPad - 2 // extra for title + hint
+	if vpWidth < 1 {
+		vpWidth = 1
+	}
+	if vpHeight < 1 {
+		vpHeight = 1
+	}
+	m.viewport.Width = vpWidth
+	m.viewport.Height = vpHeight
+	if m.loaded {
+		m.refreshContent()
+	}
 }
 
 // Init implements tea.Model.
 func (m *Model) Init() tea.Cmd { return nil }
 
-// Update implements tea.Model. Pressing Escape emits NavigateBackMsg so the
-// parent App can return focus to the narrative view.
+// Update implements tea.Model.
 func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-	if key, ok := msg.(tea.KeyMsg); ok && key.Type == tea.KeyEsc {
-		return m, func() tea.Msg { return NavigateBackMsg{} }
+	switch msg := msg.(type) {
+	case UpdateMsg:
+		m.player = msg.Player
+		m.loaded = true
+		m.refreshContent()
+		return m, nil
+
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "esc":
+			return m, func() tea.Msg { return NavigateBackMsg{} }
+		case "j", "down":
+			m.viewport.LineDown(1)
+			return m, nil
+		case "k", "up":
+			m.viewport.LineUp(1)
+			return m, nil
+		}
 	}
-	return m, nil
+
+	var cmd tea.Cmd
+	m.viewport, cmd = m.viewport.Update(msg)
+	return m, cmd
 }
 
-// View implements tea.Model and renders the character sheet placeholder.
+// View implements tea.Model and renders the character sheet.
 func (m Model) View() string {
 	title := styles.Header.Render("⚔️  Character Sheet")
 
-	placeholder := styles.SystemMessage.Render(
-		"Character data will be available in a future update.",
-	)
-	hint := styles.Muted.Render("Press Esc to return to the narrative view.")
+	if !m.loaded {
+		placeholder := styles.SystemMessage.Render("No character data available.")
+		hint := styles.Muted.Render("Press Esc to return to the narrative view.")
+		content := styles.JoinVertical(placeholder, "", hint)
+		return styles.Container.Width(m.width).Render(
+			styles.JoinVertical(title, "", content),
+		)
+	}
 
-	content := styles.JoinVertical(placeholder, "", hint)
+	hint := styles.Muted.Render("↑/↓ scroll · Esc return")
 	return styles.Container.Width(m.width).Render(
-		styles.JoinVertical(title, "", content),
+		styles.JoinVertical(title, "", m.viewport.View(), "", hint),
 	)
+}
+
+// refreshContent rebuilds the viewport content from current player data.
+func (m *Model) refreshContent() {
+	var sections []string
+
+	// Name + Level
+	nameLevel := styles.SubHeader.Render(fmt.Sprintf("%s    Level %d", m.player.Name, m.player.Level))
+	sections = append(sections, nameLevel)
+	sections = append(sections, styles.Muted.Render("━━━━━━━━━━━━━━━━━━━━━━━━━━"))
+
+	// HP bar
+	sections = append(sections, renderBar("HP", m.player.HP, m.player.MaxHP))
+
+	// XP bar
+	xpNeeded := m.player.Level * xpPerLevel
+	if xpNeeded < 1 {
+		xpNeeded = xpPerLevel
+	}
+	sections = append(sections, renderBar("XP", m.player.Experience, xpNeeded))
+
+	// Status
+	statusStyle := styles.StatusSuccess
+	switch {
+	case m.player.Status == "injured" || m.player.Status == "wounded":
+		statusStyle = styles.StatusWarning
+	case m.player.Status != "healthy" && m.player.Status != "alive" && m.player.Status != "":
+		statusStyle = styles.StatusError
+	}
+	if m.player.Status != "" {
+		sections = append(sections, fmt.Sprintf("Status: %s", statusStyle.Render(m.player.Status)))
+	}
+
+	sections = append(sections, "")
+
+	// Stats
+	sections = append(sections, m.renderStats()...)
+
+	sections = append(sections, "")
+
+	// Abilities
+	sections = append(sections, m.renderAbilities()...)
+
+	m.viewport.SetContent(strings.Join(sections, "\n"))
+}
+
+func (m *Model) renderStats() []string {
+	header := styles.SubHeader.Render("◆ Stats")
+	lines := []string{header}
+
+	if len(m.player.Stats) == 0 {
+		lines = append(lines, styles.Muted.Render("  No stats available."))
+		return lines
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal(m.player.Stats, &parsed); err != nil {
+		lines = append(lines, styles.Muted.Render("  Stats unavailable."))
+		return lines
+	}
+
+	// Sort keys for deterministic output.
+	keys := make([]string, 0, len(parsed))
+	for k := range parsed {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	// Find longest key for alignment.
+	maxLen := 0
+	for _, k := range keys {
+		if len(k) > maxLen {
+			maxLen = len(k)
+		}
+	}
+
+	for _, k := range keys {
+		label := strings.Title(k) //nolint:staticcheck // simple capitalisation
+		padded := fmt.Sprintf("%-*s", maxLen+2, label+":")
+		lines = append(lines, fmt.Sprintf("  %s %v", styles.Body.Render(padded), parsed[k]))
+	}
+	return lines
+}
+
+func (m *Model) renderAbilities() []string {
+	header := styles.SubHeader.Render("◆ Abilities")
+	lines := []string{header}
+
+	if len(m.player.Abilities) == 0 {
+		lines = append(lines, styles.Muted.Render("  No abilities available."))
+		return lines
+	}
+
+	var parsed []any
+	if err := json.Unmarshal(m.player.Abilities, &parsed); err != nil {
+		lines = append(lines, styles.Muted.Render("  Abilities unavailable."))
+		return lines
+	}
+
+	for _, raw := range parsed {
+		entry, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		name, _ := entry["name"].(string)
+		if name == "" {
+			continue
+		}
+		parts := []string{name}
+		if typ, ok := entry["type"].(string); ok && typ != "" {
+			parts = append(parts, typ)
+		}
+		if cd, ok := entry["cooldown"].(string); ok && cd != "" {
+			parts = append(parts, cd)
+		}
+		detail := strings.Join(parts[1:], ", ")
+		if detail != "" {
+			lines = append(lines, fmt.Sprintf("  • %s (%s)", name, detail))
+		} else {
+			lines = append(lines, fmt.Sprintf("  • %s", name))
+		}
+	}
+
+	if len(lines) == 1 {
+		lines = append(lines, styles.Muted.Render("  No abilities available."))
+	}
+	return lines
+}
+
+// renderBar produces a text progress bar like "HP: ████████░░░░  18/25".
+func renderBar(label string, current, max int) string {
+	if max <= 0 {
+		return fmt.Sprintf("%s: %s  %d/%d", label, styles.Muted.Render(strings.Repeat(emptyBlock, barWidth)), current, max)
+	}
+
+	ratio := float64(current) / float64(max)
+	if ratio < 0 {
+		ratio = 0
+	}
+	if ratio > 1 {
+		ratio = 1
+	}
+	filled := int(ratio * float64(barWidth))
+	empty := barWidth - filled
+
+	// Color based on percentage.
+	var barColor lipgloss.AdaptiveColor
+	switch {
+	case ratio > 0.5:
+		barColor = styles.ColorSuccess
+	case ratio > 0.25:
+		barColor = styles.ColorWarning
+	default:
+		barColor = styles.ColorError
+	}
+
+	filledStyle := lipgloss.NewStyle().Foreground(barColor)
+	filledStr := filledStyle.Render(strings.Repeat(filledBlock, filled))
+	emptyStr := styles.Muted.Render(strings.Repeat(emptyBlock, empty))
+
+	return fmt.Sprintf("%s: %s%s  %d/%d", label, filledStr, emptyStr, current, max)
 }

--- a/tui/character/character_test.go
+++ b/tui/character/character_test.go
@@ -1,29 +1,59 @@
 package character
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/google/uuid"
+
+	"github.com/PatrickFanella/game-master/internal/domain"
 )
 
 // Compile-time checks: *Model must satisfy tea.Model and the sub-model
-// interface (tea.Model + SetSize) expected by the Router. Importing the parent
-// tui package here would create a cycle, so the interface is inlined.
+// interface (tea.Model + SetSize) expected by the Router.
 var _ tea.Model = (*Model)(nil)
 var _ interface {
 	tea.Model
 	SetSize(width, height int)
 } = (*Model)(nil)
 
-func TestNewReturnsModel(t *testing.T) {
+func testPlayer() domain.PlayerCharacter {
+	return domain.PlayerCharacter{
+		ID:         uuid.New(),
+		CampaignID: uuid.New(),
+		UserID:     uuid.New(),
+		Name:       "Aric",
+		Level:      5,
+		HP:         18,
+		MaxHP:      25,
+		Experience: 1200,
+		Status:     "healthy",
+		Stats:      json.RawMessage(`{"strength":14,"dexterity":12}`),
+		Abilities:  json.RawMessage(`[{"name":"Fireball","type":"spell"},{"name":"Shield Bash","type":"melee"}]`),
+	}
+}
+
+func modelWithPlayer(t *testing.T) Model {
+	t.Helper()
+	m := New()
+	m.SetSize(80, 24)
+	updated, _ := m.Update(UpdateMsg{Player: testPlayer()})
+	return *(updated.(*Model))
+}
+
+func TestNew_ReturnsModel(t *testing.T) {
 	m := New()
 	if m.width != 0 || m.height != 0 {
 		t.Fatal("expected zero dimensions on a freshly created model")
 	}
+	if m.loaded {
+		t.Fatal("model should not be loaded initially")
+	}
 }
 
-func TestSetSizeUpdatesDimensions(t *testing.T) {
+func TestSetSize_UpdatesDimensions(t *testing.T) {
 	m := New()
 	m.SetSize(80, 24)
 	if m.width != 80 || m.height != 24 {
@@ -31,14 +61,14 @@ func TestSetSizeUpdatesDimensions(t *testing.T) {
 	}
 }
 
-func TestInitReturnsNil(t *testing.T) {
+func TestInit_ReturnsNil(t *testing.T) {
 	m := New()
 	if m.Init() != nil {
 		t.Fatal("Init() should return nil")
 	}
 }
 
-func TestEscEmitsNavigateBackMsg(t *testing.T) {
+func TestUpdate_EscEmitsNavigateBackMsg(t *testing.T) {
 	m := New()
 	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
 	if cmd == nil {
@@ -50,37 +80,112 @@ func TestEscEmitsNavigateBackMsg(t *testing.T) {
 	}
 }
 
-func TestOtherKeyReturnsNoCmd(t *testing.T) {
+func TestView_EmptyState(t *testing.T) {
 	m := New()
-	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
-	if cmd != nil {
-		t.Fatal("expected no command for non-Esc keys")
+	m.SetSize(80, 24)
+	got := m.View()
+	if !strings.Contains(got, "No character data available") {
+		t.Fatalf("expected empty state message, got:\n%s", got)
 	}
 }
 
-func TestViewContainsCharacterSheetHeader(t *testing.T) {
+func TestView_WithPlayer(t *testing.T) {
+	m := modelWithPlayer(t)
+	got := m.View()
+
+	for _, want := range []string{"Aric", "Level 5", "18", "25"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expected View to contain %q, got:\n%s", want, got)
+		}
+	}
+}
+
+func TestView_StatsRendered(t *testing.T) {
+	m := modelWithPlayer(t)
+	got := m.View()
+
+	for _, want := range []string{"Strength", "14", "Dexterity", "12"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expected View to contain stat %q, got:\n%s", want, got)
+		}
+	}
+}
+
+func TestView_AbilitiesRendered(t *testing.T) {
+	m := modelWithPlayer(t)
+	got := m.View()
+
+	for _, want := range []string{"Fireball", "Shield Bash"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expected View to contain ability %q, got:\n%s", want, got)
+		}
+	}
+}
+
+func TestView_MalformedStats(t *testing.T) {
+	m := New()
+	m.SetSize(80, 24)
+	player := testPlayer()
+	player.Stats = json.RawMessage(`invalid`)
+	updated, _ := m.Update(UpdateMsg{Player: player})
+	got := updated.(*Model).View()
+	if !strings.Contains(got, "Stats unavailable") {
+		t.Fatalf("expected 'Stats unavailable' for malformed JSON, got:\n%s", got)
+	}
+}
+
+func TestView_MalformedAbilities(t *testing.T) {
+	m := New()
+	m.SetSize(80, 24)
+	player := testPlayer()
+	player.Abilities = json.RawMessage(`invalid`)
+	updated, _ := m.Update(UpdateMsg{Player: player})
+	got := updated.(*Model).View()
+	if !strings.Contains(got, "Abilities unavailable") {
+		t.Fatalf("expected 'Abilities unavailable' for malformed JSON, got:\n%s", got)
+	}
+}
+
+func TestView_NilStats(t *testing.T) {
+	m := New()
+	m.SetSize(80, 24)
+	player := testPlayer()
+	player.Stats = nil
+	updated, _ := m.Update(UpdateMsg{Player: player})
+	got := updated.(*Model).View()
+	if !strings.Contains(got, "No stats available") {
+		t.Fatalf("expected 'No stats available' for nil Stats, got:\n%s", got)
+	}
+}
+
+func TestView_ZeroMaxHP(t *testing.T) {
+	m := New()
+	m.SetSize(80, 24)
+	player := testPlayer()
+	player.HP = 0
+	player.MaxHP = 0
+	updated, _ := m.Update(UpdateMsg{Player: player})
+	// Should not panic.
+	got := updated.(*Model).View()
+	if !strings.Contains(got, "HP:") {
+		t.Fatalf("expected HP bar even with zero max, got:\n%s", got)
+	}
+}
+
+func TestView_ContainsCharacterSheetHeader(t *testing.T) {
 	m := New()
 	m.SetSize(80, 24)
 	got := m.View()
 	if !strings.Contains(got, "Character Sheet") {
-		t.Fatalf("expected View to contain %q, got:\n%s", "Character Sheet", got)
+		t.Fatalf("expected View to contain 'Character Sheet', got:\n%s", got)
 	}
 }
 
-func TestViewContainsPlaceholderText(t *testing.T) {
-	m := New()
-	m.SetSize(80, 24)
-	got := m.View()
-	if !strings.Contains(got, "future update") {
-		t.Fatalf("expected View to contain placeholder text about a future update, got:\n%s", got)
-	}
-}
-
-func TestViewContainsEscHint(t *testing.T) {
+func TestView_ContainsEscHint(t *testing.T) {
 	m := New()
 	m.SetSize(80, 24)
 	got := m.View()
 	if !strings.Contains(got, "Esc") {
-		t.Fatalf("expected View to contain Esc key hint, got:\n%s", got)
+		t.Fatalf("expected View to contain Esc hint, got:\n%s", got)
 	}
 }

--- a/tui/inventory/inventory.go
+++ b/tui/inventory/inventory.go
@@ -1,57 +1,242 @@
 // Package inventory provides the inventory view for the TUI.
-// It renders a placeholder inventory using the shared styles package.
-// Real inventory data will be populated in the inventory management epic.
+// It renders the player's items grouped by equipped/backpack with cursor
+// navigation and item detail expansion.
 package inventory
 
 import (
-	tea "github.com/charmbracelet/bubbletea"
+	"fmt"
+	"sort"
+	"strings"
 
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/PatrickFanella/game-master/internal/domain"
 	"github.com/PatrickFanella/game-master/tui/styles"
+)
+
+const (
+	containerHPad = 4
+	containerVPad = 2
 )
 
 // NavigateBackMsg is emitted when the user presses Escape to return to the
 // narrative view.
 type NavigateBackMsg struct{}
 
+// UpdateMsg delivers fresh inventory data to the view.
+type UpdateMsg struct {
+	Items []domain.Item
+}
+
 // Model is the Bubble Tea model for the inventory view.
 type Model struct {
 	width, height int
+	items         []domain.Item
+	cursor        int
+	loaded        bool
+	viewport      viewport.Model
 }
 
 // New returns a freshly initialised inventory Model.
 func New() Model {
-	return Model{}
+	vp := viewport.New(40, 1)
+	return Model{viewport: vp}
 }
 
 // SetSize updates the viewport dimensions.
 func (m *Model) SetSize(width, height int) {
 	m.width = width
 	m.height = height
+	vpWidth := width - containerHPad
+	vpHeight := height - containerVPad - 2
+	if vpWidth < 1 {
+		vpWidth = 1
+	}
+	if vpHeight < 1 {
+		vpHeight = 1
+	}
+	m.viewport.Width = vpWidth
+	m.viewport.Height = vpHeight
+	if m.loaded {
+		m.refreshContent()
+	}
 }
 
 // Init implements tea.Model.
 func (m *Model) Init() tea.Cmd { return nil }
 
-// Update implements tea.Model. Pressing Escape emits NavigateBackMsg so the
-// parent App can return focus to the narrative view.
+// Update implements tea.Model.
 func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-	if key, ok := msg.(tea.KeyMsg); ok && key.Type == tea.KeyEsc {
-		return m, func() tea.Msg { return NavigateBackMsg{} }
+	switch msg := msg.(type) {
+	case UpdateMsg:
+		m.items = msg.Items
+		m.loaded = true
+		ordered := m.allItemsOrdered()
+		if m.cursor >= len(ordered) {
+			m.cursor = max(0, len(ordered)-1)
+		}
+		m.refreshContent()
+		return m, nil
+
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "esc":
+			return m, func() tea.Msg { return NavigateBackMsg{} }
+		case "j", "down":
+			ordered := m.allItemsOrdered()
+			if len(ordered) > 0 {
+				m.cursor = (m.cursor + 1) % len(ordered)
+				m.refreshContent()
+			}
+			return m, nil
+		case "k", "up":
+			ordered := m.allItemsOrdered()
+			if len(ordered) > 0 {
+				m.cursor = (m.cursor - 1 + len(ordered)) % len(ordered)
+				m.refreshContent()
+			}
+			return m, nil
+		}
 	}
-	return m, nil
+
+	var cmd tea.Cmd
+	m.viewport, cmd = m.viewport.Update(msg)
+	return m, cmd
 }
 
-// View implements tea.Model and renders the inventory placeholder.
+// View implements tea.Model and renders the inventory.
 func (m Model) View() string {
 	title := styles.Header.Render("🎒 Inventory")
+	if m.loaded && len(m.items) > 0 {
+		title = styles.Header.Render(fmt.Sprintf("🎒 Inventory (%d items)", len(m.items)))
+	}
 
-	placeholder := styles.SystemMessage.Render(
-		"Inventory data will be available in a future update.",
-	)
-	hint := styles.Muted.Render("Press Esc to return to the narrative view.")
+	if !m.loaded || len(m.items) == 0 {
+		msg := "Your inventory is empty."
+		if !m.loaded {
+			msg = "No inventory data available."
+		}
+		placeholder := styles.SystemMessage.Render(msg)
+		hint := styles.Muted.Render("Press Esc to return to the narrative view.")
+		content := styles.JoinVertical(placeholder, "", hint)
+		return styles.Container.Width(m.width).Render(
+			styles.JoinVertical(title, "", content),
+		)
+	}
 
-	content := styles.JoinVertical(placeholder, "", hint)
+	hint := styles.Muted.Render("↑/↓ navigate · Esc return")
 	return styles.Container.Width(m.width).Render(
-		styles.JoinVertical(title, "", content),
+		styles.JoinVertical(title, "", m.viewport.View(), "", hint),
 	)
+}
+
+// refreshContent rebuilds the viewport content from current item data.
+func (m *Model) refreshContent() {
+	equipped, backpack := m.splitItems()
+	ordered := m.allItemsOrdered()
+	var lines []string
+	idx := 0
+
+	if len(equipped) > 0 {
+		lines = append(lines, styles.SubHeader.Render("◆ Equipped"))
+		for _, item := range equipped {
+			lines = append(lines, m.renderItemLine(item, idx, true))
+			idx++
+		}
+		lines = append(lines, "")
+	}
+
+	if len(backpack) > 0 {
+		lines = append(lines, styles.SubHeader.Render("◆ Backpack"))
+		for _, item := range backpack {
+			lines = append(lines, m.renderItemLine(item, idx, false))
+			idx++
+		}
+		lines = append(lines, "")
+	}
+
+	// Selected item detail.
+	if m.cursor >= 0 && m.cursor < len(ordered) {
+		selected := ordered[m.cursor]
+		lines = append(lines, styles.Muted.Render("─── Selected ───"))
+		lines = append(lines, styles.SubHeader.Render(selected.Name))
+		if selected.Description != "" {
+			lines = append(lines, styles.Body.Render(selected.Description))
+		}
+		if selected.Rarity != "" {
+			lines = append(lines, fmt.Sprintf("Rarity: %s", styles.Muted.Render(selected.Rarity)))
+		}
+	}
+
+	m.viewport.SetContent(strings.Join(lines, "\n"))
+}
+
+func (m *Model) renderItemLine(item domain.Item, idx int, equipped bool) string {
+	cursor := "  "
+	if idx == m.cursor {
+		cursor = "> "
+	}
+
+	prefix := "  "
+	if equipped {
+		prefix = styles.StatusWarning.Render("★ ")
+	}
+
+	name := item.Name
+	if item.Quantity > 1 {
+		name = fmt.Sprintf("%s ×%d", item.Name, item.Quantity)
+	}
+
+	badge := itemTypeBadge(item.ItemType)
+	return fmt.Sprintf("%s%s%s  %s", cursor, prefix, name, badge)
+}
+
+// splitItems separates items into equipped and backpack groups, sorted by type then name.
+func (m *Model) splitItems() (equipped, backpack []domain.Item) {
+	for _, item := range m.items {
+		if item.Equipped {
+			equipped = append(equipped, item)
+		} else {
+			backpack = append(backpack, item)
+		}
+	}
+	sortItems(equipped)
+	sortItems(backpack)
+	return
+}
+
+// allItemsOrdered returns all items in display order: equipped first, then backpack.
+func (m *Model) allItemsOrdered() []domain.Item {
+	equipped, backpack := m.splitItems()
+	return append(equipped, backpack...)
+}
+
+func sortItems(items []domain.Item) {
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].ItemType != items[j].ItemType {
+			return items[i].ItemType < items[j].ItemType
+		}
+		return items[i].Name < items[j].Name
+	})
+}
+
+// itemTypeBadge returns a colored badge like [weap] for the item type.
+func itemTypeBadge(t domain.ItemType) string {
+	var label string
+	var color lipgloss.AdaptiveColor
+	switch t {
+	case domain.ItemTypeWeapon:
+		label, color = "weap", styles.ColorError
+	case domain.ItemTypeArmor:
+		label, color = "armor", styles.ColorInfo
+	case domain.ItemTypeConsumable:
+		label, color = "cons", styles.ColorSuccess
+	case domain.ItemTypeQuest:
+		label, color = "quest", styles.ColorWarning
+	default:
+		label, color = "misc", styles.ColorMuted
+	}
+	return lipgloss.NewStyle().Foreground(color).Render("[" + label + "]")
 }

--- a/tui/inventory/inventory_test.go
+++ b/tui/inventory/inventory_test.go
@@ -5,25 +5,46 @@ import (
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/google/uuid"
+
+	"github.com/PatrickFanella/game-master/internal/domain"
 )
 
 // Compile-time checks: *Model must satisfy tea.Model and the sub-model
-// interface (tea.Model + SetSize) expected by the Router. Importing the parent
-// tui package here would create a cycle, so the interface is inlined.
+// interface (tea.Model + SetSize) expected by the Router.
 var _ tea.Model = (*Model)(nil)
 var _ interface {
 	tea.Model
 	SetSize(width, height int)
 } = (*Model)(nil)
 
-func TestNewReturnsModel(t *testing.T) {
+func testItems() []domain.Item {
+	return []domain.Item{
+		{ID: uuid.New(), CampaignID: uuid.New(), Name: "Iron Sword", ItemType: domain.ItemTypeWeapon, Equipped: true, Quantity: 1, Description: "A sturdy blade.", Rarity: "common"},
+		{ID: uuid.New(), CampaignID: uuid.New(), Name: "Health Potion", ItemType: domain.ItemTypeConsumable, Equipped: false, Quantity: 3, Description: "Restores health.", Rarity: "common"},
+		{ID: uuid.New(), CampaignID: uuid.New(), Name: "Old Map", ItemType: domain.ItemTypeQuest, Equipped: false, Quantity: 1, Description: "A weathered map.", Rarity: "uncommon"},
+	}
+}
+
+func modelWithItems(t *testing.T) Model {
+	t.Helper()
+	m := New()
+	m.SetSize(80, 24)
+	updated, _ := m.Update(UpdateMsg{Items: testItems()})
+	return *(updated.(*Model))
+}
+
+func TestNew_ReturnsModel(t *testing.T) {
 	m := New()
 	if m.width != 0 || m.height != 0 {
 		t.Fatal("expected zero dimensions on a freshly created model")
 	}
+	if m.loaded {
+		t.Fatal("model should not be loaded initially")
+	}
 }
 
-func TestSetSizeUpdatesDimensions(t *testing.T) {
+func TestSetSize_UpdatesDimensions(t *testing.T) {
 	m := New()
 	m.SetSize(80, 24)
 	if m.width != 80 || m.height != 24 {
@@ -31,14 +52,14 @@ func TestSetSizeUpdatesDimensions(t *testing.T) {
 	}
 }
 
-func TestInitReturnsNil(t *testing.T) {
+func TestInit_ReturnsNil(t *testing.T) {
 	m := New()
 	if m.Init() != nil {
 		t.Fatal("Init() should return nil")
 	}
 }
 
-func TestEscEmitsNavigateBackMsg(t *testing.T) {
+func TestUpdate_EscEmitsNavigateBackMsg(t *testing.T) {
 	m := New()
 	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
 	if cmd == nil {
@@ -50,37 +71,117 @@ func TestEscEmitsNavigateBackMsg(t *testing.T) {
 	}
 }
 
-func TestOtherKeyReturnsNoCmd(t *testing.T) {
+func TestView_EmptyState(t *testing.T) {
 	m := New()
-	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
-	if cmd != nil {
-		t.Fatal("expected no command for non-Esc keys")
+	m.SetSize(80, 24)
+	// Loaded but no items.
+	updated, _ := m.Update(UpdateMsg{Items: nil})
+	got := updated.(*Model).View()
+	if !strings.Contains(got, "empty") {
+		t.Fatalf("expected empty inventory message, got:\n%s", got)
 	}
 }
 
-func TestViewContainsInventoryHeader(t *testing.T) {
-	m := New()
-	m.SetSize(80, 24)
+func TestView_WithItems(t *testing.T) {
+	m := modelWithItems(t)
+	got := m.View()
+
+	for _, want := range []string{"Iron Sword", "Health Potion", "Old Map"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expected View to contain %q, got:\n%s", want, got)
+		}
+	}
+}
+
+func TestView_EquippedGrouping(t *testing.T) {
+	m := modelWithItems(t)
+	got := m.View()
+
+	if !strings.Contains(got, "Equipped") {
+		t.Fatal("expected Equipped section header")
+	}
+	if !strings.Contains(got, "Backpack") {
+		t.Fatal("expected Backpack section header")
+	}
+	// Equipped items should have ★ indicator.
+	if !strings.Contains(got, "★") {
+		t.Fatal("expected ★ indicator for equipped items")
+	}
+}
+
+func TestView_CursorNavigation(t *testing.T) {
+	m := modelWithItems(t)
+	// Initial cursor at 0. Move down.
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+	m2 := updated.(*Model)
+	if m2.cursor != 1 {
+		t.Fatalf("expected cursor at 1 after j, got %d", m2.cursor)
+	}
+
+	// Move up wraps to last.
+	m3 := New()
+	m3.SetSize(80, 24)
+	up, _ := m3.Update(UpdateMsg{Items: testItems()})
+	m3p := up.(*Model)
+	upd, _ := m3p.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("k")})
+	m4 := upd.(*Model)
+	if m4.cursor != len(testItems())-1 {
+		t.Fatalf("expected cursor to wrap to %d, got %d", len(testItems())-1, m4.cursor)
+	}
+}
+
+func TestView_ItemDetail(t *testing.T) {
+	m := modelWithItems(t)
+	got := m.View()
+
+	// First item (cursor=0) is the equipped Iron Sword.
+	if !strings.Contains(got, "A sturdy blade") {
+		t.Fatalf("expected selected item description in detail section, got:\n%s", got)
+	}
+	if !strings.Contains(got, "Selected") {
+		t.Fatalf("expected 'Selected' separator, got:\n%s", got)
+	}
+}
+
+func TestView_QuantityDisplay(t *testing.T) {
+	m := modelWithItems(t)
+	got := m.View()
+
+	if !strings.Contains(got, "×3") {
+		t.Fatalf("expected '×3' for Health Potion quantity, got:\n%s", got)
+	}
+}
+
+func TestView_ContainsInventoryHeader(t *testing.T) {
+	m := modelWithItems(t)
 	got := m.View()
 	if !strings.Contains(got, "Inventory") {
-		t.Fatalf("expected View to contain %q, got:\n%s", "Inventory", got)
+		t.Fatalf("expected View to contain 'Inventory', got:\n%s", got)
 	}
 }
 
-func TestViewContainsPlaceholderText(t *testing.T) {
-	m := New()
-	m.SetSize(80, 24)
-	got := m.View()
-	if !strings.Contains(got, "future update") {
-		t.Fatalf("expected View to contain placeholder text about a future update, got:\n%s", got)
-	}
-}
-
-func TestViewContainsEscHint(t *testing.T) {
+func TestView_ContainsEscHint(t *testing.T) {
 	m := New()
 	m.SetSize(80, 24)
 	got := m.View()
 	if !strings.Contains(got, "Esc") {
-		t.Fatalf("expected View to contain Esc key hint, got:\n%s", got)
+		t.Fatalf("expected View to contain Esc hint, got:\n%s", got)
+	}
+}
+
+func TestView_OnlyEquipped(t *testing.T) {
+	m := New()
+	m.SetSize(80, 24)
+	items := []domain.Item{
+		{ID: uuid.New(), CampaignID: uuid.New(), Name: "Shield", ItemType: domain.ItemTypeArmor, Equipped: true, Quantity: 1},
+	}
+	updated, _ := m.Update(UpdateMsg{Items: items})
+	got := updated.(*Model).View()
+	if !strings.Contains(got, "Equipped") {
+		t.Fatal("expected Equipped section")
+	}
+	// Should not render Backpack section when all items are equipped.
+	if strings.Contains(got, "Backpack") {
+		t.Fatal("did not expect Backpack section when all items equipped")
 	}
 }

--- a/tui/quest/quest.go
+++ b/tui/quest/quest.go
@@ -1,59 +1,70 @@
 // Package quest provides the quest log view for the TUI.
-// It renders active and completed objectives using the shared styles package.
+// It renders active and completed quests with expandable objectives using
+// domain types and data delivered via UpdateMsg.
 package quest
 
 import (
+	"fmt"
+	"sort"
 	"strings"
 
+	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/google/uuid"
 
+	"github.com/PatrickFanella/game-master/internal/domain"
 	"github.com/PatrickFanella/game-master/tui/styles"
 )
+
+const (
+	containerHPad = 4
+	containerVPad = 2
+)
+
+// Status group display order.
+var statusOrder = []domain.QuestStatus{
+	domain.QuestStatusActive,
+	domain.QuestStatusCompleted,
+	domain.QuestStatusFailed,
+	domain.QuestStatusAbandoned,
+}
+
+// statusLabels maps quest status to display header text.
+var statusLabels = map[domain.QuestStatus]string{
+	domain.QuestStatusActive:    "Active",
+	domain.QuestStatusCompleted: "Completed",
+	domain.QuestStatusFailed:    "Failed",
+	domain.QuestStatusAbandoned: "Abandoned",
+}
 
 // NavigateBackMsg is emitted when the user presses Escape to return to the
 // narrative view.
 type NavigateBackMsg struct{}
 
-// ObjectiveStatus tracks whether an objective is pending, completed, or failed.
-type ObjectiveStatus int
-
-const (
-	StatusPending ObjectiveStatus = iota
-	StatusComplete
-	StatusFailed
-)
-
-// Objective is a single task within a quest.
-type Objective struct {
-	Description string
-	Status      ObjectiveStatus
-}
-
-// Quest groups a name with its list of objectives.
-type Quest struct {
-	Name       string
-	Objectives []Objective
+// UpdateMsg delivers fresh quest data to the view.
+type UpdateMsg struct {
+	Quests     []domain.Quest
+	Objectives map[uuid.UUID][]domain.QuestObjective
 }
 
 // Model is the Bubble Tea model for the quest log view.
 type Model struct {
 	width, height int
-	Quests        []Quest
+	quests        []domain.Quest
+	objectives    map[uuid.UUID][]domain.QuestObjective
+	cursor        int
+	expanded      map[uuid.UUID]bool
+	loaded        bool
+	viewport      viewport.Model
 }
 
-// New returns a freshly initialised quest Model with a placeholder quest.
+// New returns a freshly initialised quest Model.
 func New() Model {
+	vp := viewport.New(40, 1)
 	return Model{
-		Quests: []Quest{
-			{
-				Name: "The Missing Merchant",
-				Objectives: []Objective{
-					{Description: "Speak to the innkeeper", Status: StatusComplete},
-					{Description: "Investigate the east road", Status: StatusPending},
-					{Description: "Find the missing cart", Status: StatusPending},
-				},
-			},
-		},
+		viewport: vp,
+		expanded: make(map[uuid.UUID]bool),
 	}
 }
 
@@ -61,53 +72,207 @@ func New() Model {
 func (m *Model) SetSize(width, height int) {
 	m.width = width
 	m.height = height
+	vpWidth := width - containerHPad
+	vpHeight := height - containerVPad - 2
+	if vpWidth < 1 {
+		vpWidth = 1
+	}
+	if vpHeight < 1 {
+		vpHeight = 1
+	}
+	m.viewport.Width = vpWidth
+	m.viewport.Height = vpHeight
+	if m.loaded {
+		m.refreshContent()
+	}
 }
 
 // Init implements tea.Model.
 func (m *Model) Init() tea.Cmd { return nil }
 
-// Update implements tea.Model. Pressing Escape emits NavigateBackMsg so the
-// parent App can return focus to the narrative view.
+// Update implements tea.Model.
 func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-	if key, ok := msg.(tea.KeyMsg); ok && key.Type == tea.KeyEsc {
-		return m, func() tea.Msg { return NavigateBackMsg{} }
+	switch msg := msg.(type) {
+	case UpdateMsg:
+		m.quests = msg.Quests
+		m.objectives = msg.Objectives
+		if m.objectives == nil {
+			m.objectives = make(map[uuid.UUID][]domain.QuestObjective)
+		}
+		m.loaded = true
+
+		// Default-expand active quests.
+		m.expanded = make(map[uuid.UUID]bool)
+		for _, q := range m.quests {
+			if q.Status == domain.QuestStatusActive {
+				m.expanded[q.ID] = true
+			}
+		}
+
+		ordered := m.orderedQuests()
+		if m.cursor >= len(ordered) {
+			m.cursor = max(0, len(ordered)-1)
+		}
+		m.refreshContent()
+		return m, nil
+
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "esc":
+			return m, func() tea.Msg { return NavigateBackMsg{} }
+		case "j", "down":
+			ordered := m.orderedQuests()
+			if len(ordered) > 0 {
+				m.cursor = (m.cursor + 1) % len(ordered)
+				m.refreshContent()
+			}
+			return m, nil
+		case "k", "up":
+			ordered := m.orderedQuests()
+			if len(ordered) > 0 {
+				m.cursor = (m.cursor - 1 + len(ordered)) % len(ordered)
+				m.refreshContent()
+			}
+			return m, nil
+		case "enter":
+			ordered := m.orderedQuests()
+			if m.cursor >= 0 && m.cursor < len(ordered) {
+				qid := ordered[m.cursor].ID
+				m.expanded[qid] = !m.expanded[qid]
+				m.refreshContent()
+			}
+			return m, nil
+		}
 	}
-	return m, nil
+
+	var cmd tea.Cmd
+	m.viewport, cmd = m.viewport.Update(msg)
+	return m, cmd
 }
 
 // View implements tea.Model and renders the quest log.
 func (m Model) View() string {
 	title := styles.Header.Render("📜 Quest Log")
 
-	var sections []string
-	for _, q := range m.Quests {
-		questName := styles.SubHeader.Render("◆ " + q.Name)
-		var objLines []string
-		for _, obj := range q.Objectives {
-			objLines = append(objLines, renderObjective(obj))
+	if !m.loaded || len(m.quests) == 0 {
+		msg := "No quests yet. Your adventure awaits."
+		if !m.loaded {
+			msg = "No quest data available."
 		}
-		sections = append(sections, styles.JoinVertical(
-			append([]string{questName}, objLines...)...,
-		))
+		placeholder := styles.SystemMessage.Render(msg)
+		hint := styles.Muted.Render("Press Esc to return to the narrative view.")
+		content := styles.JoinVertical(placeholder, "", hint)
+		return styles.Container.Width(m.width).Render(
+			styles.JoinVertical(title, "", content),
+		)
 	}
 
-	if len(sections) == 0 {
-		sections = []string{styles.Muted.Render("  No active quests.")}
-	}
-
-	content := strings.Join(sections, "\n\n")
+	hint := styles.Muted.Render("↑/↓ navigate · Enter expand · Esc return")
 	return styles.Container.Width(m.width).Render(
-		styles.JoinVertical(title, "", content),
+		styles.JoinVertical(title, "", m.viewport.View(), "", hint),
 	)
 }
 
-func renderObjective(obj Objective) string {
-	switch obj.Status {
-	case StatusComplete:
-		return styles.StatusSuccess.Render("  ✓ ") + styles.Muted.Render(obj.Description)
-	case StatusFailed:
-		return styles.StatusError.Render("  ✗ ") + styles.Muted.Render(obj.Description)
-	default:
-		return styles.Muted.Render("  ○ ") + styles.Body.Render(obj.Description)
+// refreshContent rebuilds the viewport content.
+func (m *Model) refreshContent() {
+	ordered := m.orderedQuests()
+	grouped := m.groupByStatus()
+
+	var sections []string
+	idx := 0
+
+	for _, status := range statusOrder {
+		quests := grouped[status]
+		if len(quests) == 0 {
+			continue
+		}
+
+		label, ok := statusLabels[status]
+		if !ok {
+			label = string(status)
+		}
+		sections = append(sections, styles.SubHeader.Render("◆ "+label))
+
+		for _, q := range quests {
+			_ = ordered // cursor indexes into the full ordered list
+
+			cursor := "  "
+			if idx == m.cursor {
+				cursor = "> "
+			}
+
+			expand := "▸ "
+			if m.expanded[q.ID] {
+				expand = "▾ "
+			}
+
+			badge := questTypeBadge(q.QuestType)
+			line := fmt.Sprintf("%s%s%s %s", cursor, expand, q.Title, badge)
+			sections = append(sections, line)
+
+			if m.expanded[q.ID] {
+				objs := m.sortedObjectives(q.ID)
+				for _, obj := range objs {
+					sections = append(sections, renderObjective(obj))
+				}
+			}
+			idx++
+		}
+		sections = append(sections, "")
 	}
+
+	m.viewport.SetContent(strings.Join(sections, "\n"))
+}
+
+// orderedQuests returns quests in display order: active → completed → failed → abandoned.
+func (m *Model) orderedQuests() []domain.Quest {
+	grouped := m.groupByStatus()
+	var result []domain.Quest
+	for _, status := range statusOrder {
+		result = append(result, grouped[status]...)
+	}
+	return result
+}
+
+// groupByStatus groups quests by their status.
+func (m *Model) groupByStatus() map[domain.QuestStatus][]domain.Quest {
+	grouped := make(map[domain.QuestStatus][]domain.Quest)
+	for _, q := range m.quests {
+		grouped[q.Status] = append(grouped[q.Status], q)
+	}
+	return grouped
+}
+
+// sortedObjectives returns objectives for a quest sorted by OrderIndex.
+func (m *Model) sortedObjectives(questID uuid.UUID) []domain.QuestObjective {
+	objs := make([]domain.QuestObjective, len(m.objectives[questID]))
+	copy(objs, m.objectives[questID])
+	sort.Slice(objs, func(i, j int) bool {
+		return objs[i].OrderIndex < objs[j].OrderIndex
+	})
+	return objs
+}
+
+func renderObjective(obj domain.QuestObjective) string {
+	if obj.Completed {
+		return styles.StatusSuccess.Render("  ✓ ") + styles.Muted.Render(obj.Description)
+	}
+	return styles.Muted.Render("  ○ ") + styles.Body.Render(obj.Description)
+}
+
+// questTypeBadge returns a colored type indicator.
+func questTypeBadge(t domain.QuestType) string {
+	var label string
+	var color lipgloss.AdaptiveColor
+	switch t {
+	case domain.QuestTypeShortTerm:
+		label, color = "[ST]", styles.ColorSuccess
+	case domain.QuestTypeMediumTerm:
+		label, color = "[MT]", styles.ColorWarning
+	case domain.QuestTypeLongTerm:
+		label, color = "[LT]", styles.ColorAccent
+	default:
+		label, color = "[??]", styles.ColorMuted
+	}
+	return lipgloss.NewStyle().Foreground(color).Render(label)
 }

--- a/tui/quest/quest_test.go
+++ b/tui/quest/quest_test.go
@@ -5,32 +5,58 @@ import (
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/google/uuid"
+
+	"github.com/PatrickFanella/game-master/internal/domain"
 )
 
 // Compile-time checks: *Model must satisfy tea.Model and the sub-model
-// interface (tea.Model + SetSize) expected by the Router. Importing the parent
-// tui package here would create a cycle, so the interface is inlined.
+// interface (tea.Model + SetSize) expected by the Router.
 var _ tea.Model = (*Model)(nil)
 var _ interface {
 	tea.Model
 	SetSize(width, height int)
 } = (*Model)(nil)
 
-func TestNewReturnsModel(t *testing.T) {
+func testQuestData() ([]domain.Quest, map[uuid.UUID][]domain.QuestObjective) {
+	questID1 := uuid.New()
+	questID2 := uuid.New()
+	quests := []domain.Quest{
+		{ID: questID1, Title: "The Missing Merchant", QuestType: domain.QuestTypeShortTerm, Status: domain.QuestStatusActive},
+		{ID: questID2, Title: "Welcome to Town", QuestType: domain.QuestTypeMediumTerm, Status: domain.QuestStatusCompleted},
+	}
+	objectives := map[uuid.UUID][]domain.QuestObjective{
+		questID1: {
+			{ID: uuid.New(), QuestID: questID1, Description: "Speak to the innkeeper", Completed: true, OrderIndex: 0},
+			{ID: uuid.New(), QuestID: questID1, Description: "Investigate east road", Completed: false, OrderIndex: 1},
+		},
+	}
+	return quests, objectives
+}
+
+func modelWithQuests(t *testing.T) Model {
+	t.Helper()
+	m := New()
+	m.SetSize(80, 24)
+	quests, objectives := testQuestData()
+	updated, _ := m.Update(UpdateMsg{Quests: quests, Objectives: objectives})
+	return *(updated.(*Model))
+}
+
+func TestNew_ReturnsModel(t *testing.T) {
 	m := New()
 	if m.width != 0 || m.height != 0 {
 		t.Fatal("expected zero dimensions on a freshly created model")
 	}
-}
-
-func TestNewHasPlaceholderQuest(t *testing.T) {
-	m := New()
-	if len(m.Quests) == 0 {
-		t.Fatal("expected at least one placeholder quest")
+	if m.loaded {
+		t.Fatal("model should not be loaded initially")
+	}
+	if len(m.quests) != 0 {
+		t.Fatal("expected no quests on a freshly created model")
 	}
 }
 
-func TestSetSizeUpdatesDimensions(t *testing.T) {
+func TestSetSize_UpdatesDimensions(t *testing.T) {
 	m := New()
 	m.SetSize(80, 24)
 	if m.width != 80 || m.height != 24 {
@@ -38,14 +64,14 @@ func TestSetSizeUpdatesDimensions(t *testing.T) {
 	}
 }
 
-func TestInitReturnsNil(t *testing.T) {
+func TestInit_ReturnsNil(t *testing.T) {
 	m := New()
 	if m.Init() != nil {
 		t.Fatal("Init() should return nil")
 	}
 }
 
-func TestEscEmitsNavigateBackMsg(t *testing.T) {
+func TestUpdate_EscEmitsNavigateBackMsg(t *testing.T) {
 	m := New()
 	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
 	if cmd == nil {
@@ -57,38 +83,136 @@ func TestEscEmitsNavigateBackMsg(t *testing.T) {
 	}
 }
 
-func TestOtherKeyReturnsNoCmd(t *testing.T) {
+func TestView_EmptyState(t *testing.T) {
 	m := New()
-	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
-	if cmd != nil {
-		t.Fatal("expected no command for non-Esc keys")
+	m.SetSize(80, 24)
+	updated, _ := m.Update(UpdateMsg{Quests: nil})
+	got := updated.(*Model).View()
+	if !strings.Contains(got, "No quests yet") {
+		t.Fatalf("expected empty quest message, got:\n%s", got)
 	}
 }
 
-func TestViewContainsQuestLogHeader(t *testing.T) {
+func TestView_WithQuests(t *testing.T) {
+	m := modelWithQuests(t)
+	got := m.View()
+
+	for _, want := range []string{"The Missing Merchant", "Welcome to Town"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expected View to contain %q, got:\n%s", want, got)
+		}
+	}
+
+	// Verify status grouping.
+	if !strings.Contains(got, "Active") {
+		t.Fatal("expected Active section header")
+	}
+	if !strings.Contains(got, "Completed") {
+		t.Fatal("expected Completed section header")
+	}
+}
+
+func TestView_ObjectivesRendered(t *testing.T) {
+	m := modelWithQuests(t)
+	got := m.View()
+
+	// Active quest should be auto-expanded.
+	if !strings.Contains(got, "Speak to the innkeeper") {
+		t.Fatalf("expected completed objective text, got:\n%s", got)
+	}
+	if !strings.Contains(got, "Investigate east road") {
+		t.Fatalf("expected pending objective text, got:\n%s", got)
+	}
+	// Check markers.
+	if !strings.Contains(got, "✓") {
+		t.Fatal("expected ✓ marker for completed objective")
+	}
+	if !strings.Contains(got, "○") {
+		t.Fatal("expected ○ marker for pending objective")
+	}
+}
+
+func TestView_ExpandCollapse(t *testing.T) {
+	m := modelWithQuests(t)
+
+	// Active quest at cursor 0 should be expanded. Press Enter to collapse.
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m2 := updated.(*Model)
+	got := m2.View()
+
+	// After collapsing, objectives should not appear.
+	if strings.Contains(got, "Speak to the innkeeper") {
+		t.Fatal("expected objectives to be hidden after collapse")
+	}
+
+	// Press Enter again to re-expand.
+	updated2, _ := m2.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m3 := updated2.(*Model)
+	got2 := m3.View()
+	if !strings.Contains(got2, "Speak to the innkeeper") {
+		t.Fatal("expected objectives to reappear after re-expanding")
+	}
+}
+
+func TestView_QuestTypeBadges(t *testing.T) {
+	m := modelWithQuests(t)
+	got := m.View()
+
+	if !strings.Contains(got, "[ST]") {
+		t.Fatal("expected [ST] badge for short term quest")
+	}
+	if !strings.Contains(got, "[MT]") {
+		t.Fatal("expected [MT] badge for medium term quest")
+	}
+}
+
+func TestView_CursorNavigation(t *testing.T) {
+	m := modelWithQuests(t)
+	// Move cursor down.
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+	m2 := updated.(*Model)
+	if m2.cursor != 1 {
+		t.Fatalf("expected cursor at 1 after j, got %d", m2.cursor)
+	}
+
+	// Wrap around.
+	updated2, _ := m2.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+	m3 := updated2.(*Model)
+	if m3.cursor != 0 {
+		t.Fatalf("expected cursor to wrap to 0, got %d", m3.cursor)
+	}
+}
+
+func TestView_ContainsQuestLogHeader(t *testing.T) {
 	m := New()
 	m.SetSize(80, 24)
 	got := m.View()
 	if !strings.Contains(got, "Quest Log") {
-		t.Fatalf("expected View to contain %q, got:\n%s", "Quest Log", got)
+		t.Fatalf("expected View to contain 'Quest Log', got:\n%s", got)
 	}
 }
 
-func TestViewContainsPlaceholderQuest(t *testing.T) {
+func TestView_ContainsEscHint(t *testing.T) {
 	m := New()
 	m.SetSize(80, 24)
 	got := m.View()
-	if !strings.Contains(got, "Missing Merchant") {
-		t.Fatalf("expected View to contain placeholder quest name, got:\n%s", got)
+	if !strings.Contains(got, "Esc") {
+		t.Fatalf("expected View to contain Esc hint, got:\n%s", got)
 	}
 }
 
-func TestViewEmptyQuestsShowsNoActiveQuests(t *testing.T) {
+func TestView_NoObjectivesQuest(t *testing.T) {
 	m := New()
-	m.Quests = nil
 	m.SetSize(80, 24)
-	got := m.View()
-	if !strings.Contains(got, "No active quests") {
-		t.Fatalf("expected View to contain %q when no quests, got:\n%s", "No active quests", got)
+	quests := []domain.Quest{
+		{ID: uuid.New(), Title: "Solo Quest", QuestType: domain.QuestTypeLongTerm, Status: domain.QuestStatusActive},
+	}
+	updated, _ := m.Update(UpdateMsg{Quests: quests, Objectives: nil})
+	got := updated.(*Model).View()
+	if !strings.Contains(got, "Solo Quest") {
+		t.Fatalf("expected quest title, got:\n%s", got)
+	}
+	if !strings.Contains(got, "[LT]") {
+		t.Fatal("expected [LT] badge")
 	}
 }


### PR DESCRIPTION
## Summary

Replace placeholder TUI views with real data-driven implementations and wire real-time state updates.

### Changes

**Engine layer:** Extend GameState with PlayerInventory and ActiveQuestObjectives.

**Character view:** Viewport-based rendering with stats, abilities, HP/XP bars, UpdateMsg.

**Inventory view:** Grouped equipped/backpack, cursor navigation, item detail panel.

**Quest log view:** Status grouping, expand/collapse, quest type badges.

**App wiring:** fetchGameState on init + post-turn, distributeState to sub-views, error surfacing.

### Tests
- 40+ new view tests + app integration tests for init fetch, post-turn refresh, error handling
- All 97 existing TUI tests pass

Closes #118, #119, #120, #137